### PR TITLE
Add arm32v6 Dockerfile

### DIFF
--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -1,0 +1,46 @@
+FROM debian:buster AS builder
+
+# Download QEMU, see https://github.com/docker/hub-feedback/issues/1261
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    apt-utils \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt -qyy clean
+RUN export QEMU_USER_STATIC_LATEST_TAG=$(curl -s https://api.github.com/repos/multiarch/qemu-user-static/tags \
+        | grep 'name.*v[0-9]' | head -n 1 | cut -d '"' -f 4) && \
+    curl -SL "https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_USER_STATIC_LATEST_TAG}/x86_64_qemu-arm-static.tar.gz" \
+        | tar xzv --directory /
+
+FROM arm32v6/alpine:edge
+
+COPY --from=builder /qemu-arm-static /usr/bin/
+
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+
+LABEL maintainer="osintsev@gmail.com" \
+    org.label-schema.license="MIT" \
+    org.label-schema.vendor="Distirbuted Solutions, Inc." \
+    org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.name="Tor network client (daemon)" \
+    org.label-schema.description="Tor network client (daemon) with simple usage" \
+    org.label-schema.url="https://www.torproject.org" \
+    org.label-schema.vcs-url="https://github.com/osminogin/docker-tor-simple" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.usage="https://github.com/osminogin/docker-tor-simple#getting-started" \
+    org.label-schema.docker.cmd="docker run -d --rm --publish 127.0.0.1:9050:9050 --name tor osminogin/tor-simple" \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.version=$VERSION
+
+RUN apk add --no-cache tor && \
+    sed "1s/^/SocksPort 0.0.0.0:9050\n/" /etc/tor/torrc.sample > /etc/tor/torrc
+
+EXPOSE 9050
+
+VOLUME ["/var/lib/tor"]
+
+USER tor
+
+CMD ["/usr/bin/tor"]


### PR DESCRIPTION
Add Dockerfile that builds an image that should work on a raspberrypi armv32v6.

This Dockerfile has special source that should let it also build on dockerhub.
Here is a link to a working repo: https://hub.docker.com/repository/docker/guysoft/tor-simple 

It is also possible to create a [multiarch tag](https://hub.docker.com/r/ckulka/multi-arch-example) using dockerhub hooks.