### PR TITLE
Modify healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache curl tor && \
 EXPOSE 9050
 
 HEALTHCHECK --interval=60s --timeout=15s --start-period=20s \
-    CMD curl -s --socks5 127.0.0.1:9050 'https://check.torproject.org/' | grep -qm1 Congratulations
+    CMD curl -s --socks5 127.0.0.1:9050 'https://check.torproject.org/api/ip' | grep -qm1 -E '"IsTor"\s*:\s*true'
 
 VOLUME ["/var/lib/tor"]
 


### PR DESCRIPTION
Change check to use API because it should be lighter on torproject website and on the whole tor network (0.33KB per request versus 4.94KB).