### PR TITLE
Use tor network for dns requests for healhcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache curl tor && \
 EXPOSE 9050
 
 HEALTHCHECK --interval=60s --timeout=15s --start-period=20s \
-    CMD curl -s --socks5 127.0.0.1:9050 'https://check.torproject.org/api/ip' | grep -qm1 -E '"IsTor"\s*:\s*true'
+    CMD curl -x socks5h://127.0.0.1:9050 'https://check.torproject.org/api/ip' | grep -qm1 -E '"IsTor"\s*:\s*true'
 
 VOLUME ["/var/lib/tor"]
 


### PR DESCRIPTION
To prevent dns leaking we can change the curl healthcheck command to do dns requests through tor.
See here: https://tor.stackexchange.com/questions/12678/how-to-check-if-tor-is-working-and-debug-the-problem-on-cli#comment13892_13079